### PR TITLE
Remove OrthographicSize from properties of SobelFilter

### DIFF
--- a/Assets/Rendering/blitMaterial.mat
+++ b/Assets/Rendering/blitMaterial.mat
@@ -105,7 +105,6 @@ Material:
     - _GlossyReflections: 0
     - _Metallic: 0
     - _OcclusionStrength: 1
-    - _OrthographicSize: 9.786845
     - _Parallax: 0.005
     - _PixelDensity: 0.03125
     - _PosterizationCount: 8

--- a/Assets/Scripts/Rendering/SobleFilter.shader
+++ b/Assets/Scripts/Rendering/SobleFilter.shader
@@ -3,7 +3,6 @@ Shader "Unlit/SobelFilter"
     Properties
     {
         [HideInInspector]_MainTex ("Base (RGB)", 2D) = "white" {}
-        [HideInInspector]_OrthographicSize ("OrthographicSize", float) = 1
         _OutlineColor ("Outline Color", COLOR) = (0, 0, 0, 1)
         _PixelDensity ("Pixel Density", float) = 10
         _Power ("Power", float) = 50


### PR DESCRIPTION
As per commit, the functionality of the render does not change, only prevents blitMaterial.mat from appearing as a change in git each time camera is moved.